### PR TITLE
Add example pages for new JS opt out

### DIFF
--- a/consent/optout_javascript_custom.php
+++ b/consent/optout_javascript_custom.php
@@ -1,0 +1,69 @@
+<?php include '../bootstrap.php'; ?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>OptOut using Javascript</title>
+    <!-- Matomo -->
+    <script type="text/javascript">
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        _paq.push(['enableJSErrorTracking']);
+        (function () {
+            var u = "<?php echo $matomoUrl ?>/";
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', '<?php echo $matomoIdSite ?>']);
+            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+            g.type = 'text/javascript';
+            g.async = true;
+            g.src = u + 'matomo.js';
+            s.parentNode.insertBefore(g, s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+
+</head>
+<body>
+<h1>OptOut using Javascript</h1>
+
+The default JS out-out as explained on
+<a href="https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form">
+    https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form
+</a>.
+
+<div id="optout-form">
+    <p>You may choose not to have a unique web analytics cookie identification number assigned to your computer to avoid
+        the aggregation and analysis of data collected on this website.</p>
+    <p>To make that choice, please click below to receive an opt-out cookie.</p>
+
+    <p>
+        <input type="checkbox" id="optout"/>
+        <label for="optout"><strong></strong></label>
+    </p>
+</div>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function (event) {
+        function setOptOutText(element) {
+            _paq.push([function () {
+                element.checked = !this.isUserOptedOut();
+                document.querySelector('label[for=optout] strong').innerText = this.isUserOptedOut()
+                    ? 'You are currently opted out. Click here to opt in.'
+                    : 'You are currently opted in. Click here to opt out.';
+            }]);
+        }
+
+        var optOut = document.getElementById("optout");
+        optOut.addEventListener("click", function () {
+            if (this.checked) {
+                _paq.push(['forgetUserOptOut']);
+            } else {
+                _paq.push(['optUserOut']);
+            }
+            setOptOutText(optOut);
+        });
+        setOptOutText(optOut);
+    });
+</script>

--- a/consent/optout_javascript_loaded_matomojs_with_delay.php
+++ b/consent/optout_javascript_loaded_matomojs_with_delay.php
@@ -2,11 +2,18 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Out out using regular OptOutJS</title>
+    <title>Opt out using OptOutJS. The Tracker is loaded with a delay of multiple seconds</title>
 
     <!-- Matomo -->
     <script>
 
+        // Test variables
+        let loadTracker = true;
+        let maxRandomDelay = 10;
+        let minRandomDelay = 5;
+        // ---
+
+        function loadMatomoTracker() {
             console.log('.. now loading Matomo tracker');
             var _paq = window._paq = window._paq || [];
             _paq.push(['trackPageView']);
@@ -18,6 +25,15 @@
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                 g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
             })();
+        }
+
+        if (loadTracker === true)  {
+            let randomInterval = (Math.floor((Math.floor(Math.random() * ((maxRandomDelay * 1000) - (minRandomDelay * 1000)) ) + (minRandomDelay * 1000)) / 1000) * 1000);
+            setTimeout(function() { loadMatomoTracker() }, randomInterval);
+            console.log('delaying Matomo tracker load for '+randomInterval / 1000+' seconds...');
+        } else {
+            console.log('tracker loading disabled');
+        }
     </script>
     <!-- End Matomo Code -->
 

--- a/consent/optout_javascript_tracker_not_loaded.php
+++ b/consent/optout_javascript_tracker_not_loaded.php
@@ -1,0 +1,16 @@
+<?php include '../bootstrap.php'; ?>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Opt out using OptOutJS. The tracker is not loaded, only the opt out</title>
+
+</head>
+<body>
+OptOutJS
+<br><br>
+
+<div id="matomo-opt-out" style="text-align:center;width:350px;padding:10px">...opt-out loading...</div>
+<script src="<?php echo $matomoUrl ?>/index.php?module=CoreAdminHome&action=optOutJS&useCookiesTimeout=10&div=m-opt-out&language=auto&backgroundColor=BBBBFF&fontColor=444444&fontSize=16px&fontFamily=TimesNewRoman&showIntro=1&useCookiesIfNoTracker=1"></script>
+
+</body>
+</html>


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/pull/19528

fyi @bx80 @sgiehl 

adding 3 examples based off https://github.com/matomo-org/matomo/pull/19528#issuecomment-1193553663

* Loading tracker right away
* Loading tracker delayed
* Loading tracker not at all

Haven't added any example yet re cookies etc.

If the examples are OK we could maybe merge once #19528 is merged.